### PR TITLE
chore: add type module to react hooks package json

### DIFF
--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -10,6 +10,7 @@
   "homepage": "",
   "license": "MIT",
   "main": "index.js",
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/acolorbright/react-tools.git"


### PR DESCRIPTION
It seems this line needs to be added for the package to be treated as an ES module (instead of CommonJS) https://stackoverflow.com/a/68558580