### PR TITLE
improvement: make usemediaquery compatible with older safari

### DIFF
--- a/packages/react-hooks/hooks/useMediaQuery.ts
+++ b/packages/react-hooks/hooks/useMediaQuery.ts
@@ -13,8 +13,20 @@ export const useMediaQuery = (query: string): boolean => {
     const listener = () => {
       setMatches(media.matches)
     }
-    media.addEventListener('change', listener)
-    return () => media.removeEventListener('change', listener)
+
+    if (media.addEventListener) {
+      media.addEventListener('change', listener)
+    } else {
+      media.addListener(listener)
+    }
+
+    return () => {
+      if (media.removeEventListener) {
+        media.removeEventListener('change', listener)
+      } else {
+        media.removeListener(listener)
+      }
+    }
   }, [matches, query])
 
   return matches


### PR DESCRIPTION
This makes `useMediaQuery` compatible with Safari 13. I think it's worth adding since it's a small and quick fix, but let me know if you disagree